### PR TITLE
Rebuild spacy-transformers 1.1.5 for py311

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,11 @@ requirements:
     - spacy-alignments >=0.7.2,<1.0.0
 
 test:
-  requires:
-    - pip check
-    #- pytest
   imports:
     - {{ module_name }}
+  requires:
+    - pip
+    #- pytest
   commands:
     - pip check
     #- python -m pytest --tb=native --pyargs {{ module_name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,32 +13,37 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - spacy >=3.1.3,<4.0.0
-    - transformers >=3.4.0,<4.12.0
+    - transformers >=3.4.0,<4.18.0
     - pytorch >=1.6.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
 
 test:
-#  requires:
-#    - pytest
+  requires:
+    - pip check
+    #- pytest
   imports:
     - {{ module_name }}
-#  commands:
-#    - python -m pytest --tb=native --pyargs {{ module_name }}
+  commands:
+    - pip check
+#   - python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Use pretrained transformers like BERT, XLNet and GPT-2 in spaCy
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python >=3.6
     - spacy >=3.1.3,<4.0.0
     - transformers >=3.4.0,<4.18.0
-    - pytorch >=1.6.0
+    - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - {{ module_name }}
   commands:
     - pip check
-#   - python -m pytest --tb=native --pyargs {{ module_name }}
+    #- python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io


### PR DESCRIPTION
Requirements: https://github.com/explosion/spacy-transformers/blob/v1.1.5/requirements.txt

Actions:
1. Bump build number
2. Add missing setuptools and wheel
3. Fix transformers's upper bound
4. Add pip check

Notes:
- As we rebuild the package we do not remove `noarch: python`
- As it's a noarch package you can ignore the failing s390x platform