### PR TITLE
[PKG-1664] spacy-transformers 1.2.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - {{ compiler('cxx') }}
   host:
     - python
     - cython 0.29.32

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,9 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - pytorch >=1.8.0
+    # TODO: Working around osx bug importing two openmp variants.
+    - pytorch >=1.8.0     # [not (osx and x86_64)]
+    - pytorch >1.9,<1.12  # [osx and x86_64]
     - spacy >=3.5.0,<4.0.0
     - spacy-alignments >=0.7.2,<1.0.0
     - srsly >=2.4.0,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ test:
   requires:
     - pip
     - pytest >=5.2.0
-    - pytest-cov >=2.7.0,<2.8.0
   imports:
     - {{ module_name }}
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spacy-transformers" %}
 {% set module_name = "spacy_transformers" %}
-{% set version = "1.2.3" %}
+{% set version = "1.2.4" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a0d747d2864da3c5d6c7e6dbcf066cee25c3d007facf1d64eb005892c82da78c
+  sha256: 859c2093fad9ff41005bc55c0018d4290bdd62454f76bddbcf318aae85f307b5
 
 build:
   number: 0
@@ -37,7 +37,6 @@ requirements:
     - spacy >=3.5.0,<4.0.0
     - spacy-alignments >=0.7.2,<1.0.0
     - srsly >=2.4.0,<3.0.0
-    # Workaround to extend the upper bound
     - transformers >=3.4.0,<4.30.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,10 @@ build:
   number: 0
   # spacy isn't available on s390x
   skip: True  # [py<36 or s390x]
+  # At present, there are no 3.11 compatible Pytorch version for win or ppc
+  # There is a bug requiring PyTorch 1.10 on osx-64 which is not available for 3.11
+  # As transformers 4.29.2 b0 has the same issue, we apply its skipping logic here  
+  skip: True  # [py>310 and (ppc64le or win or (osx and x86_64))]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -25,6 +29,8 @@ requirements:
     - cython 0.29.32
     - numpy {{ numpy }}
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - {{ pin_compatible('numpy') }}
@@ -32,7 +38,8 @@ requirements:
     - spacy >=3.5.0,<4.0.0
     - spacy-alignments >=0.7.2,<1.0.0
     - srsly >=2.4.0,<3.0.0
-    - transformers >=3.4.0,<4.29.0
+    # Workaround to extend the upper bound
+    - transformers >=3.4.0,<4.30.0
 
 test:
   requires:
@@ -47,6 +54,7 @@ test:
 about:
   home: https://spacy.io
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Use pretrained transformers like BERT, XLNet and GPT-2 in spaCy
   description: |
@@ -62,3 +70,5 @@ extra:
     - honnibal
     - ines
     - adrianeboyd
+  skip-lints:
+    - cython_needs_compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,8 @@ test:
     - {{ module_name }}
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs {{ module_name }}
+    # tests take too long (hours) on ppc64le and aarch64 
+    - python -m pytest --tb=native --pyargs {{ module_name }}  # [not linux and (ppc64le or aarch64)]
 
 about:
   home: https://spacy.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spacy-transformers" %}
 {% set module_name = "spacy_transformers" %}
-{% set version = "1.1.5" %}
+{% set version = "1.2.3" %}
 
 package:
   name: {{ name }}
@@ -8,33 +8,40 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f16e69c5c87a6d6dee4ceeb422d84086a01a7152ebad742b58db4787b060cf2
+  sha256: a0d747d2864da3c5d6c7e6dbcf066cee25c3d007facf1d64eb005892c82da78c
 
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  # spacy isn't available on s390x
+  skip: True  # [py<36 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
+    - cython 0.29.32
+    - numpy {{ numpy }}
     - pip
   run:
-    - python >=3.6
-    - spacy >=3.1.3,<4.0.0
-    - transformers >=3.4.0,<4.12.0
-    - pytorch >=1.6.0
-    - srsly >=2.4.0,<3.0.0
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pytorch >=1.8.0
+    - spacy >=3.5.0,<4.0.0
     - spacy-alignments >=0.7.2,<1.0.0
+    - srsly >=2.4.0,<3.0.0
+    - transformers >=3.4.0,<4.29.0
 
 test:
-#  requires:
-#    - pytest
+  requires:
+    - pip
+    - pytest >=5.2.0
+    - pytest-cov >=2.7.0,<2.8.0
   imports:
     - {{ module_name }}
-#  commands:
-#    - python -m pytest --tb=native --pyargs {{ module_name }}
+  commands:
+    - pip check
+    - python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io


### PR DESCRIPTION
Changelog: https://github.com/explosion/spacy-transformers/releases
License: https://github.com/explosion/spacy-transformers/blob/v1.2.4/LICENSE
Requirements:
- https://github.com/explosion/spacy-transformers/blob/v1.2.4/pyproject.toml
- https://github.com/explosion/spacy-transformers/blob/v1.2.4/setup.cfg
- https://github.com/explosion/spacy-transformers/blob/v1.2.4/setup.py

Actions:
1. Skip `py>310 and (ppc64le or win or (osx and x86_64))` because of lack of Pytorch on win64 and ppc64e for python 3.11
2. Update pinnings
3. Working around osx bug importing two openmp variants.
4. Enable `pip check`