### PR TITLE
spacy-transformers 1.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,36 @@
 {% set name = "spacy-transformers" %}
 {% set module_name = "spacy_transformers" %}
-{% set version = "1.1.5" %}
+{% set version = "1.3.5" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9f16e69c5c87a6d6dee4ceeb422d84086a01a7152ebad742b58db4787b060cf2
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: accdfe44a26517714c6990ec6bae88796eb348286fea7ba20ba2736f70c83fa1
 
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
+  build:
+    - {{ compiler('cxx') }}
   host:
-    - python >=3.6
+    - python
+    - cython >=0.25
+    - numpy {{ numpy }}
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - spacy >=3.1.3,<4.0.0
-    - transformers >=3.4.0,<4.12.0
-    - pytorch >=1.6.0
+    - python
+    - {{ pin_compatible('numpy') }}
+    - spacy >=3.5.0,<4.1.0
+    - transformers >=3.4.0,<4.37.0
+    - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -v
 
 requirements:
   build:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2733](https://anaconda.atlassian.net/browse/PKG-2733) 
- [Upstream repository](https://github.com/explosion/spacy-transformers/tree/v1.3.5)
- Requirements:
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/build-constraints.txt
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/pyproject.toml
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/requirements.txt
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/setup.cfg
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/setup.py

### Explanation of changes:

- Clean up the recipe by conda-linter
- Add a compiler to build
- Add cython and numpy to host
- Update runtime pinnings

### Notes:

- Updating because of the `pytorch 2.3.0` release

[PKG-2733]: https://anaconda.atlassian.net/browse/PKG-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ