### PR TITLE
spacy-transformers 1.3.5

### DIFF
--- a/recipe/fix-transformers-upper-bound.patch
+++ b/recipe/fix-transformers-upper-bound.patch
@@ -1,0 +1,38 @@
+From c7c0ba7aa63df99216cf1f1f36d346db39f3dea8 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Mon, 1 Jul 2024 12:40:34 +0300
+Subject: [PATCH] Fix transformers upper bound
+
+---
+ requirements.txt | 2 +-
+ setup.cfg        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/requirements.txt b/requirements.txt
+index c24f081..88a32bd 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,6 +1,6 @@
+ spacy>=3.5.0,<4.1.0
+ numpy>=1.15.0
+-transformers[sentencepiece]>=3.4.0,<4.37.0
++transformers[sentencepiece]>=3.4.0,<4.42.0
+ torch>=1.8.0
+ srsly>=2.4.0,<3.0.0
+ dataclasses>=0.6,<1.0; python_version < "3.7"
+diff --git a/setup.cfg b/setup.cfg
+index b728a34..f7f1c92 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -33,7 +33,7 @@ install_requires =
+     spacy>=3.5.0,<4.1.0
+     numpy>=1.15.0; python_version < "3.9"
+     numpy>=1.19.0; python_version >= "3.9"
+-    transformers>=3.4.0,<4.37.0
++    transformers>=3.4.0,<4.42.0
+     torch>=1.8.0
+     srsly>=2.4.0,<3.0.0
+     dataclasses>=0.6,<1.0; python_version < "3.7"
+-- 
+2.44.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,26 @@
 {% set name = "spacy-transformers" %}
 {% set module_name = "spacy_transformers" %}
-{% set version = "1.2.4" %}
+{% set version = "1.3.5" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 859c2093fad9ff41005bc55c0018d4290bdd62454f76bddbcf318aae85f307b5
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: accdfe44a26517714c6990ec6bae88796eb348286fea7ba20ba2736f70c83fa1
+
 
 build:
   number: 0
-  # spacy isn't available on s390x
-  skip: True  # [py<36 or s390x]
-  # At present, there are no 3.11 compatible Pytorch version for win or ppc
-  # There is a bug requiring PyTorch 1.10 on osx-64 which is not available for 3.11
-  # As transformers 4.29.2 b0 has the same issue, we apply its skipping logic here  
-  skip: True  # [py>310 and (ppc64le or win or (osx and x86_64))]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
     - {{ compiler('cxx') }}
   host:
     - python
-    - cython 0.29.32
+    - cython >=0.25
     - numpy {{ numpy }}
     - pip
     - setuptools
@@ -33,29 +28,23 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    # TODO: Working around osx bug importing two openmp variants.
-    - pytorch >=1.8.0     # [not (osx and x86_64)]
-    - pytorch >1.9,<1.12  # [osx and x86_64]
-    - spacy >=3.5.0,<4.0.0
-    - spacy-alignments >=0.7.2,<1.0.0
+    - spacy >=3.5.0,<4.1.0
+    - transformers >=3.4.0,<4.37.0
+    - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
-    - transformers >=3.4.0,<4.30.0
+    - spacy-alignments >=0.7.2,<1.0.0
 
 test:
-  requires:
-    - pip
-    - pytest >=5.2.0
+#  requires:
+#    - pytest
   imports:
     - {{ module_name }}
-  commands:
-    - pip check
-    # tests take too long (hours) on ppc64le and aarch64 
-    - python -m pytest --tb=native --pyargs {{ module_name }}  # [not linux and (ppc64le or aarch64)]
+#  commands:
+#    - python -m pytest --tb=native --pyargs {{ module_name }}
 
 about:
   home: https://spacy.io
   license: MIT
-  license_family: MIT
   license_file: LICENSE
   summary: Use pretrained transformers like BERT, XLNet and GPT-2 in spaCy
   description: |
@@ -63,7 +52,7 @@ about:
     models via Hugging Face's transformers in spaCy. The result is convenient
     access to state-of-the-art transformer architectures, such as BERT, GPT-2,
     XLNet, etc.
-  doc_url: https://spacy.io/usage/embeddings-transformers
+  doc_url: https://github.com/explosion/spacy-transformers
   dev_url: https://github.com/explosion/spacy-transformers
 
 extra:
@@ -71,5 +60,3 @@ extra:
     - honnibal
     - ines
     - adrianeboyd
-  skip-lints:
-    - cython_needs_compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,13 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - spacy >=3.5.0,<4.1.0
+    # transformers[sentencepiece] means 'extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")',
+    # see https://github.com/explosion/spacy-transformers/blob/v1.3.5/requirements.txt#L3-L3C28 and
+    # https://github.com/huggingface/transformers/blob/345b9b1a6a308a1fa6559251eb33ead2211240ac/setup.py#L300-L300C65
+    # Anaconda set the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.42.0
+    - sentencepiece >=0.1.91,!=0.1.92
+    - protobuf
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
   run_constrained:
-    pydantic >=1.0.0,<2.0.0
+    - pydantic >=1.0.0,<2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   number: 0
   # spacy isn't available on s390x.
   # spacy-transformers through spacy and pydantic <2.7.4 aren't compatible with python 3.12 currently 
-  skip: True  # [s390x or py<312]
+  skip: True  # [s390x or py>312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   number: 0
   # spacy isn't available on s390x.
   # spacy-transformers through spacy and pydantic <2.7.4 aren't compatible with python 3.12 currently 
-  skip: True  # [s390x or py>312]
+  skip: True  # [s390x or py>311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ requirements:
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
+  run_constrained:
+    pydantic >=1.0.0,<2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,3 +81,5 @@ extra:
     - honnibal
     - ines
     - adrianeboyd
+  skip-lints:
+    - cython_needs_compiler

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
   number: 0
   # spacy isn't available on s390x.
   # spacy-transformers through spacy and pydantic <2.7.4 aren't compatible with python 3.12 currently 
-  skip: True  # [s390x or py>311]
+  skip: True  # [s390x or py<37 or py>311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -43,6 +43,7 @@ requirements:
     - transformers >=3.4.0,<4.42.0
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
+    - dataclasses >=0.6  # [py<37]
     - spacy-alignments >=0.7.2,<1.0.0
   run_constrained:
     - pydantic >=1.0.0,<2.0.0
@@ -72,7 +73,7 @@ about:
     models via Hugging Face's transformers in spaCy. The result is convenient
     access to state-of-the-art transformer architectures, such as BERT, GPT-2,
     XLNet, etc.
-  doc_url: https://github.com/explosion/spacy-transformers
+  doc_url: https://spacy.io/usage/embeddings-transformers
   dev_url: https://github.com/explosion/spacy-transformers
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,20 +7,26 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: accdfe44a26517714c6990ec6bae88796eb348286fea7ba20ba2736f70c83fa1
-
+  # To apply fix-transformers-upper-bound.patch we need the same setup.cfg as on the GitHub but this file is different on PyPI.
+  # When the patch won't be required then the PyPI tarball can be back again
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://github.com/explosion/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 2da7ad6706590253d759fce6bd01640a9fb595d586ca7ae47eb774c274ee73a6
+  patches:
+    # This patch might not be needed at the time of the next release.
+    - fix-transformers-upper-bound.patch
 
 build:
   number: 0
   # spacy isn't available on s390x.
-  # transformers isn't available for py>=312 currently.
-  skip: True  # [s390x or py>311]
+  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - python
     - cython >=0.25
@@ -32,24 +38,25 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - spacy >=3.5.0,<4.1.0
-    # transformers[sentencepiece] means 'extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")',
-    # see https://github.com/explosion/spacy-transformers/blob/v1.3.5/requirements.txt#L3-L3C28 and
-    # https://github.com/huggingface/transformers/blob/345b9b1a6a308a1fa6559251eb33ead2211240ac/setup.py#L300-L300C65
-    # Anaconda set the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
+    # Anaconda applies a patch and sets the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.42.0
-    - sentencepiece >=0.1.91,!=0.1.92
-    - protobuf
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
 
 test:
-#  requires:
-#    - pytest
+  requires:
+    - pip
+    - pytest >=5.2.0
+    # test_pipeline_component.py::test_transformer_sentencepiece_IO:
+    # XLMRobertaTokenizer requires the SentencePiece library
+    - sentencepiece
   imports:
     - {{ module_name }}
-#  commands:
-#    - python -m pytest --tb=native --pyargs {{ module_name }}
+  commands:
+    - pip check
+    # tests take too long (hours) on ppc64le and aarch64
+    - python -m pytest --tb=native --pyargs {{ module_name }}  # [not (linux and aarch64)]
 
 about:
   home: https://spacy.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ source:
 
 build:
   number: 0
+  # spacy isn't available on s390x.
+  # transformers isn't available for py>=312 currently.
+  skip: True  # [s390x or py>311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -29,7 +32,7 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - spacy >=3.5.0,<4.1.0
-    - transformers >=3.4.0,<4.37.0
+    - transformers >=3.4.0,<4.42.0
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - spacy-alignments >=0.7.2,<1.0.0
@@ -45,6 +48,7 @@ test:
 about:
   home: https://spacy.io
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Use pretrained transformers like BERT, XLNet and GPT-2 in spaCy
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,8 @@ source:
 build:
   number: 0
   # spacy isn't available on s390x.
-  skip: True  # [s390x]
+  # spacy-transformers through spacy and pydantic <2.7.4 aren't compatible with python 3.12 currently 
+  skip: True  # [s390x or py<312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2733](https://anaconda.atlassian.net/browse/PKG-2733) 
- [Upstream repository](https://github.com/explosion/spacy-transformers/tree/v1.3.5)
- Requirements:
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/build-constraints.txt
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/pyproject.toml
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/requirements.txt
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/setup.cfg
  - https://github.com/explosion/spacy-transformers/blob/v1.3.5/setup.py

### Explanation of changes:

- Clean up the recipe by conda-linter
- Add a compiler to `build`
- Add `cython` and `numpy` to `host`
- Update runtime pinnings, add missing `sentencepiece` and `protobuf` (extracting them from `transformers[sentencepiece]`), see https://github.com/explosion/spacy-transformers/blob/ba6bf8202662f59aa1862bd4c5dd6fd0119a3335/requirements.txt#L3-L3C28

### Notes:

- Updating because of the `pytorch 2.3.0` release


[PKG-2733]: https://anaconda.atlassian.net/browse/PKG-2733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ