### PR TITLE
Rebuild: support py312

### DIFF
--- a/recipe/fix-transformers-upper-bound.patch
+++ b/recipe/fix-transformers-upper-bound.patch
@@ -16,7 +16,7 @@ index c24f081..88a32bd 100644
  spacy>=3.5.0,<4.1.0
  numpy>=1.15.0
 -transformers[sentencepiece]>=3.4.0,<4.37.0
-+transformers[sentencepiece]>=3.4.0,<4.42.0
++transformers[sentencepiece]>=3.4.0,<4.45.3
  torch>=1.8.0
  srsly>=2.4.0,<3.0.0
  dataclasses>=0.6,<1.0; python_version < "3.7"
@@ -29,7 +29,7 @@ index b728a34..f7f1c92 100644
      numpy>=1.15.0; python_version < "3.9"
      numpy>=1.19.0; python_version >= "3.9"
 -    transformers>=3.4.0,<4.37.0
-+    transformers>=3.4.0,<4.42.0
++    transformers>=3.4.0,<4.45.3
      torch>=1.8.0
      srsly>=2.4.0,<3.0.0
      dataclasses>=0.6,<1.0; python_version < "3.7"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,17 +31,17 @@ requirements:
     - python
     - cython >=0.25
     - numpy>=1.15.0,<2.0.0  # [py<39]
-    - numpy>=1.25.0,<3.0.0  # [py>=39]
+    - numpy>=2.0.0,<3.0.0  # [py>=39]
     - pip
     - setuptools
     - wheel
   run:
     - python
     - numpy>=1.15.0,<2.0.0  # [py<39]
-    - numpy>=1.25.0,<3.0.0  # [py>=39]
+    - numpy>=2.0.0,<3.0.0  # [py>=39]
     - spacy >=3.5.0,<4.1.0
-    # Anaconda applies a patch and sets the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
-    - transformers >=3.4.0,<4.42.0
+    # Anaconda applies a patch and sets the transformers upper bound to <4.45.3 because of compatibility with 'tokenisers' versions
+    - transformers >=3.4.0,<4.45.3
     - pytorch >=1.8.0
     - srsly >=2.4.0,<3.0.0
     - dataclasses >=0.6  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,8 @@ requirements:
     - wheel
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.15.0  # [py<39]
+    - numpy>=1.25.0  # [py>=39]
     - spacy >=3.5.0,<4.1.0
     # Anaconda applies a patch and sets the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.42.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,9 @@ source:
     - fix-transformers-upper-bound.patch
 
 build:
-  number: 0
+  number: 1
   # spacy isn't available on s390x.
-  # spacy-transformers through spacy and pydantic <2.7.4 aren't compatible with python 3.12 currently 
-  skip: True  # [s390x or py<37 or py>311]
+  skip: True  # [s390x or py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -45,8 +44,6 @@ requirements:
     - srsly >=2.4.0,<3.0.0
     - dataclasses >=0.6  # [py<37]
     - spacy-alignments >=0.7.2,<1.0.0
-  run_constrained:
-    - pydantic >=1.0.0,<2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,11 @@ requirements:
     - srsly >=2.4.0,<3.0.0
     - dataclasses >=0.6  # [py<37]
     - spacy-alignments >=0.7.2,<1.0.0
+  run_constraned:
+    - pydantic >=2.0.0,<3.0.0  # [py<312]
+    # as referenced in https://github.com/pydantic/pydantic/issues/9637#issuecomment-2162873917, older than 2.7.4
+    # presents an error with py312 "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
+    - pydantic >=2.7.4,<3.0.0  # [py>=312]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ requirements:
     - wheel
   run:
     - python
-    - numpy>=1.15.0  # [py<39]
-    - numpy>=1.25.0  # [py>=39]
+    - numpy>=1.15.0,<2.0.0  # [py<39]
+    - numpy>=1.25.0,<3.0.0  # [py>=39]
     - spacy >=3.5.0,<4.1.0
     # Anaconda applies a patch and sets the transformers upper bound to <4.42.0 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.42.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,8 @@ requirements:
   host:
     - python
     - cython >=0.25
-    - numpy {{ numpy }}
+    - numpy>=1.15.0,<2.0.0  # [py<39]
+    - numpy>=1.25.0,<3.0.0  # [py>=39]
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 build:
   number: 1
   # spacy isn't available on s390x.
-  skip: True  # [s390x or py<37]
+  skip: True  # [s390x or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
@@ -30,16 +30,13 @@ requirements:
   host:
     - python
     - cython >=0.25
-    - numpy>=1.15.0,<2.0.0  # [py<39]
     - numpy>=2.0.0,<3.0.0  # [py>=39]
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - numpy>=1.15.0,<2.0.0  # [py<39]
     - numpy>=2.0.0,<3.0.0  # [py>=39]
-    - spacy >=3.5.2,<4.1.0  # [py<39]
     - spacy >=3.8.0,<4.1.0  # [py>=39]
     # Anaconda applies a patch and sets the transformers upper bound to <4.45.3 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.45.3
@@ -47,11 +44,6 @@ requirements:
     - srsly >=2.4.0,<3.0.0
     - dataclasses >=0.6  # [py<37]
     - spacy-alignments >=0.7.2,<1.0.0
-  run_constraned:
-    - pydantic >=2.0.0,<3.0.0  # [py<312]
-    # as referenced in https://github.com/pydantic/pydantic/issues/9637#issuecomment-2162873917, older than 2.7.4
-    # presents an error with py312 "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
-    - pydantic >=2.7.4,<3.0.0  # [py>=312]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,14 +30,14 @@ requirements:
   host:
     - python
     - cython >=0.25
-    - numpy>=2.0.0,<3.0.0  # [py>=39]
+    - numpy >=2.0.0,<2.1.0
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - numpy>=2.0.0,<3.0.0  # [py>=39]
-    - spacy >=3.8.0,<4.1.0  # [py>=39]
+    - numpy >=2.0.0,<2.1.0
+    - spacy >=3.8.0,<4.1.0
     # Anaconda applies a patch and sets the transformers upper bound to <4.45.3 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.45.3
     - pytorch >=1.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,8 @@ requirements:
     - python
     - numpy>=1.15.0,<2.0.0  # [py<39]
     - numpy>=2.0.0,<3.0.0  # [py>=39]
-    - spacy >=3.5.0,<4.1.0
+    - spacy >=3.5.2,<4.1.0  # [py<39]
+    - spacy >=3.8.0,<4.1.0  # [py>=39]
     # Anaconda applies a patch and sets the transformers upper bound to <4.45.3 because of compatibility with 'tokenisers' versions
     - transformers >=3.4.0,<4.45.3
     - pytorch >=1.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - patch     # [not win]
   host:
     - python
-    - cython >=0.25
+    - cython >=0.25,<3.0
     - numpy >=2.0.0,<2.1.0
     - pip
     - setuptools


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira]() 
- [Upstream repository]()

### Explanation of changes:

- Do not skip `py312`
- Add constraints for `pydantic` in run_constrained, see https://github.com/AnacondaRecipes/spacy-transformers-feedstock/pull/9#issuecomment-2199846504

### Notes:

-